### PR TITLE
fix: 配列の要素数を超えたアクセスを修正

### DIFF
--- a/Assets/Script/issue_practice.cs
+++ b/Assets/Script/issue_practice.cs
@@ -8,7 +8,7 @@ public class issue_practice : MonoBehaviour
     void Start()
     {
         int[] a = { 1, 2, 3, 4, 5 };
-        for (int i = 0; i < 6; i++)
+        for (int i = 0; i < a.Length; i++)
         {
             Debug.Log(a[i]);
         }


### PR DESCRIPTION
Close #2 
## 課題
- https://github.com/https://github.com/CC-Circle/github-practice/issues/2

## 概要

issueで指摘された、配列の要素数を超えたアクセスを修正

## 変更点

- 配列にアクセスするためのfor文の条件式に、配列の要素数ではなくArray.Lengthを使用する。

## チェックリスト

- [x]  コンパイルできるか？
- [x] issueで指摘されたエラーは解消されたか？ 

## その他
- こんな感じで、issueとプルリクエストを紐づけることができます。